### PR TITLE
Implement video archiving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ config/master.key
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed
-# .env
+.env
 
 ## Environment normalization:
 /.bundle

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ node_modules/
 /public/packs
 /public/packs-test
 /public/assets
+/public/videos
 
 # Ignore yarn files
 /yarn-error.log

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bundle exec rails server -p 8282 -b '0.0.0.0'
 webpacker: ./bin/webpacker-dev-server
-worker: bundle exec rails jobs:work
+worker: QUEUE=default bundle exec rails jobs:work

--- a/app/admin/channels.rb
+++ b/app/admin/channels.rb
@@ -7,7 +7,7 @@ ActiveAdmin.register Channel do
 
   controller do
     def model_params
-      params.require(:channel).permit(:name, :position)
+      params.require(:channel).permit(:name, :position, :archive_videos)
     end
 
     def update
@@ -27,6 +27,9 @@ ActiveAdmin.register Channel do
   index download_links: false do
     column :position
     column :name
+    column 'Current Video' do |channel|
+      link_to channel.current_queue_item&.video&.name, channel.current_queue_item&.video
+    end
     column 'Total Videos' do |channel|
       channel.videos.size
     end
@@ -34,6 +37,7 @@ ActiveAdmin.register Channel do
       # convert to hours, formatted in hours:minues:seconds
       channel.videos.length_str
     end
+    column :archive_videos
     actions
   end
 

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page "Dashboard" do
         columns do
           column span: 3 do
             panel '', id: 'video-player-panel' do
-              video id: 'video-player', class: 'video-js' do
+              video id: 'video-player', class: 'video-js', type: 'video/mp4' do
                 source src: 'blank.mp4', type: 'video/mp4'
               end
             end

--- a/app/admin/settings.rb
+++ b/app/admin/settings.rb
@@ -100,8 +100,9 @@ end
 
 def settings
   {
-    'premium' => {name: 'Premium', field_type: :checkbox, description: 'Allow premium videos to be played.'},
-    'play_jwplayer' => {name: 'Play JW Player Videos', field_type: :checkbox, description: 'Allow playing videos with JWPlayer URLs. Starting ~2023-02-01, GB started using the JWPlayer CDN. The JWPlayer URLs provided have short expiry times, requiring the API to be hit every time the video is queued up on order to get a new URL. If you have a lot of channels, this can result in you hitting the hourly API limit. Leaving this setting disabled will prevent new videos from being added to your channel queues.'},
-    'quality_play_order' => {name: 'Quality Play Order', field_type: :text, description: 'Comma separated list of qualities to play in order of preference. Example: "hd,high,low"'},
+    'premium' => { name: 'Premium', field_type: :checkbox, description: 'Allow premium videos to be played.' },
+    'play_jwplayer' => { name: 'Play JW Player Videos', field_type: :checkbox, description: 'Allow playing videos with JWPlayer URLs. Starting ~2023-02-01, GB started using the JWPlayer CDN. The JWPlayer URLs provided have short expiry times, requiring the API to be hit every time the video is queued up on order to get a new URL. If you have a lot of channels, this can result in you hitting the hourly API limit. Leaving this setting disabled will prevent new videos from being added to your channel queues.' },
+    'quality_play_order' => { name: 'Quality Play Order', field_type: :text, description: 'Comma separated list of qualities to play in order of preference. Example: "hd,high,low"' },
+    'archive_path' => { name: 'Archive Path', field_type: :text, description: 'Local directory to archive videos to. Example: "/Users/user_name/media/gb_videos" or "C:/media/gb_videos". You also need to enable the Archive Videos setting on individual channels for videos to save. Docker restart required for changes to take effect' },
   }
 end

--- a/app/javascript/channels/channels_channel.js
+++ b/app/javascript/channels/channels_channel.js
@@ -42,7 +42,7 @@ $(window).on('load', function() {
       channel_el.addClass('playing')
 
       if (channels[key].queue.length > 0) {
-        player.src(buildUrl(channels[key].queue[0]))
+        player.src({ type: 'video/mp4', src: buildUrl(channels[key].queue[0]) })
 
         updateWhatsPlaying(channels[key].queue[0])
       } else {

--- a/app/jobs/archive_job.rb
+++ b/app/jobs/archive_job.rb
@@ -1,0 +1,13 @@
+class ArchiveJob < ApplicationJob
+  queue_as :default
+
+  def perform()
+    return unless Setting.archive_path.present?
+
+    current_videos = Channel.where(archive_videos: true).
+                     map { |x| x.current_queue_item&.video if !x.current_queue_item&.video.archived }.uniq.compact
+    current_videos.each do |video|
+      video.archive_video
+    end
+  end
+end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,16 +1,34 @@
 class Setting < RailsSettings::Base
   cache_prefix { "v1" }
-  after_create :sync_video_on_first_save
-  after_update :sync_video_on_first_save
+  after_create :sync_video_on_first_save, :add_archive_path_to_env
+  after_update :sync_video_on_first_save, :add_archive_path_to_env
 
   field :gb_api_key, type: :string, default: ''
   field :premium, type: :boolean, default: true
   field :play_jwplayer, type: :boolean, default: false
   field :quality_play_order, type: :string, default: 'hd,high,low'
+  field :archive_path, type: :string, default: ''
 
   def sync_video_on_first_save
     if self.var == 'gb_api_key' && (saved_change_to_value?(from: nil) || Video.all.size.zero?)
       VideoSyncJob.perform_later(nil)
+    end
+  end
+
+  def add_archive_path_to_env
+    if var == 'archive_path' && saved_change_to_value?
+      env_file = Rails.root.join('.env')
+      if File.exist?(env_file)
+        env = File.read(env_file)
+        if env.match(/^ARCHIVE_PATH=/)
+          env.gsub!(/^ARCHIVE_PATH=.*/, "ARCHIVE_PATH=#{Setting.archive_path}")
+        else
+          env += "\nARCHIVE_PATH=#{Setting.archive_path}"
+        end
+        File.write(env_file, env)
+      else
+        File.write(env_file, "ARCHIVE_PATH=#{Setting.archive_path}")
+      end
     end
   end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -7,11 +7,18 @@ class Video < ApplicationRecord
                youtube_id]
   end
 
-  def get_url(quality = nil)
+  def get_url(quality = nil, request = nil, return_quality = false, return_archived = true)
+    if archived && File.exist?(archive_fullpath) && return_archived
+      return archive_url(request)
+    elsif archived && !File.exist?(archive_fullpath)
+      update(archived: false, archived_quality: nil)
+    end
+
     if (video_urls['hd'] || video_urls['high'] || video_urls['low']).exclude?('giantbomb.com')
       update_urls
     end
 
+    qualities = Setting.quality_play_order.split(',')
     if quality
       url = video_urls["#{quality}"]
       if url.nil?
@@ -24,7 +31,6 @@ class Video < ApplicationRecord
         end
       end
     else
-      qualities = Setting.quality_play_order.split(',')
       url = qualities.map { |q| video_urls[q] }.compact.first
     end
 
@@ -32,7 +38,11 @@ class Video < ApplicationRecord
       url += "?api_key=#{Setting.gb_api_key}"
     end
 
-    url
+    if return_quality
+      [url, qualities.find { |q| video_urls[q] == (url.gsub("?api_key=#{Setting.gb_api_key}", '')) }]
+    else
+      url
+    end
   end
 
   def update_urls
@@ -68,5 +78,68 @@ class Video < ApplicationRecord
     days = sum(:length) / (3600 * 24)
     day_s = days > 1 ? 's' : ''
     "#{days.to_s + " day#{day_s}, " if days.positive?}#{(sum(:length) / 3600) % 24}:#{"%02d" % ((sum(:length) / 60) % 60)}:#{"%02d" % (sum(:length) % 60)}"
+  end
+
+  def archive_filename
+    "#{api_id}.mp4"
+  end
+
+  def archive_path
+    if show_id.present?
+      File.join('public', 'archive', "#{show_id}")
+    else
+      File.join('public', 'archive')
+    end
+  end
+
+  def archive_fullpath
+    File.join(Rails.root, archive_path, archive_filename)
+  end
+
+  def archive_url(request = nil)
+    (request&.protocol.to_s + request&.host_with_port.to_s) +
+      if show_id.present?
+        File.join('/archive', "#{show_id}", archive_filename)
+      else
+        File.join('/archive', archive_filename)
+      end
+  end
+
+  def archive_video
+    FileUtils.mkdir_p(archive_path)
+    if archived && !File.exist?(archive_fullpath)
+      update(archived: false, archived_quality: nil)
+    end
+
+    Setting.quality_play_order.split(',').each do |qual|
+      url = get_url(qual, nil, true, false)
+
+      # Use HTTParty to download the video. Resume the download if the existing filesize is less than the remote file
+      # size. This is a workaround for the fact that HTTParty doesn't support resuming downloads.
+      remote_size = HTTParty.head(url[0]).headers['content-length'].to_i
+      if File.exist?(archive_fullpath)
+        local_size = File.size(archive_fullpath)
+        if local_size < remote_size
+          puts "Resuming download of #{archive_filename} at #{local_size} bytes"
+          File.open(archive_fullpath, 'ab') do |file|
+            file.write HTTParty.get(url[0], headers: { 'Range' => "bytes=#{local_size}-" }).body
+          end
+        else
+          update(archived: true, archived_quality: url[1])
+          puts "Skipping download of #{archive_filename} because it already exists"
+        end
+      else
+        puts "Downloading #{archive_filename}"
+        File.open(archive_fullpath, 'wb') do |file|
+          # stream the download to the file
+          HTTParty.get(url[0], stream_body: true) do |fragment|
+            file.write(fragment)
+          end
+        end
+      end
+
+      update(archived: true, archived_quality: url[1]) if remote_size == File.size(archive_fullpath)
+      break
+    end
   end
 end

--- a/app/views/channels/_form.html.erb
+++ b/app/views/channels/_form.html.erb
@@ -21,6 +21,13 @@
       <%= f.number_field :position %>
     </li>
     <% end %>
+    <li class="string input optional stringish" id="channel_archive_videos_input">
+      <%= f.label :archive_videos, class: "label" do %>
+        Archive Videos
+        <span class="status_tag ?" title="When enabled, videos will be downloaded to the Archive Path specified in the Settings page. The downloader will prioritize the download quality based on the play order specified in the settings. Subsequently, when an archived video is played on a channel, the stored file will be played instead of being streamed from Giant Bomb">?</span>
+      <% end %>
+      <%= f.check_box :archive_videos %>
+    </li>
   </ol>
 </fieldset>
 <div class="tabs ui-tabs ui-corner-all ui-widget ui-widget-content">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,11 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
+  config.middleware.insert_after(ActionDispatch::Static, Rack::Deflater)
+  config.public_file_server.headers = {
+    'Accept-Ranges' => 'bytes'
+  }
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp/caching-dev.txt').exist?

--- a/db/migrate/20230620214251_add_archive_atts_to_video.rb
+++ b/db/migrate/20230620214251_add_archive_atts_to_video.rb
@@ -1,0 +1,7 @@
+class AddArchiveAttsToVideo < ActiveRecord::Migration[7.0]
+  def change
+    add_column :videos, :archived, :boolean, default: false
+    add_column :videos, :archived_quality, :string, default: nil
+    add_column :channels, :archive_videos, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_233603) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_20_214251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_233603) do
     t.datetime "updated_at", null: false
     t.jsonb "q", default: {}
     t.integer "position"
+    t.boolean "archive_videos", default: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -120,6 +121,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_233603) do
     t.datetime "updated_at", null: false
     t.boolean "error_on_last_play", default: false
     t.datetime "error_on_last_play_at"
+    t.boolean "archived", default: false
+    t.string "archived_quality"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,11 @@ services:
   web:
     build: .
     command: >
-      bash -c "bundle exec foreman start -f Procfile.dev"
+      bash -c "bundle exec foreman start -f Procfile.dev -m web=1,webpacker=1,worker=2"
     volumes:
       - .:/usr/src/app
       - bundle:/usr/local/bundle
+      - ${ARCHIVE_PATH}:/usr/src/app/public/archive
     ports:
       - "8282:8282"
       - "3035:3035"


### PR DESCRIPTION
## Implement Video Archiving
Adds the ability to archive videos to the host machine. Channels now have a setting to allow the videos that play on it to be archived. The app checks in the background while videos play, and downloads the video if it has not already been downloaded. Once downloaded, if that video plays again in the future, it will play from the local file rather than download/stream it again from the Giant Bomb servers